### PR TITLE
Allow for a more flexible Pulp URL

### DIFF
--- a/roles/post_install_config/README.md
+++ b/roles/post_install_config/README.md
@@ -8,6 +8,6 @@ Variables
 * `pulp_install_dir`: Location of a virtual environment for Pulp and its Python dependencies. Defaults to "/usr/local/lib/pulp". 
 * `pulp_user`: System user that owns and runs Pulp. Defaults to "pulp". 
 * `pulp_default_admin_password`: Initial password for the Pulp admin. Defaults to "password".
-* `pulp_api_host`: Host for connecting to the Pulp API server. Defaults to "127.0.0.1".
-* `pulp_api_port`: Port used for connecting to the Pulp API server. Defaults to "24817".
+* `pulp_url`: URL for connecting to the Pulp API server. Defaults to "http://127.0.0.1:24817/".
 * `pulp_settings_file`: Location of the Django setings files. Defaults to "{{ pulp_config_dir }}/settings.py".
+* `pulp_validate_certs`: Whether or not the TLS certificates should be verified. Defaults to "true".

--- a/roles/post_install_config/defaults/main.yml
+++ b/roles/post_install_config/defaults/main.yml
@@ -4,5 +4,5 @@ pulp_install_dir: '/usr/local/lib/pulp'
 pulp_settings_file: '{{ pulp_config_dir }}/settings.py'
 pulp_user: pulp
 pulp_default_admin_password: password
-pulp_api_host: 127.0.0.1
-pulp_api_port: 24817
+pulp_url: 'http://127.0.0.1:24817/'
+pulp_validate_certs: true

--- a/roles/post_install_config/tasks/main.yml
+++ b/roles/post_install_config/tasks/main.yml
@@ -1,8 +1,9 @@
 - name: Ensure Pulp is up and healthy
   pulp.squeezer.status:
-    pulp_url: "http://{{ pulp_api_host }}:{{ pulp_api_port }}"
+    pulp_url: "{{ pulp_url }}"
     username: "{{ pulp_admin_username }}"
     password: "{{ pulp_default_admin_password }}"
+    validate_certs: "{{ pulp_validate_certs | bool }}"
   register: result
   until: >
     result.status is defined and
@@ -15,9 +16,10 @@
 
 - name: Create default repositories
   pulp.squeezer.ansible_repository:
-    pulp_url: "http://{{ pulp_api_host }}:{{ pulp_api_port }}"
+    pulp_url: "{{ pulp_url }}"
     username: "{{ pulp_admin_username }}"
     password: "{{ pulp_default_admin_password }}"
+    validate_certs: "{{ pulp_validate_certs | bool }}"
     name: "{{ item.repo_name }}"
     description: "{{ item.description }}"
     state: present
@@ -25,9 +27,10 @@
 
 - name: Create default distributions
   pulp.squeezer.ansible_distribution:
-    pulp_url: "http://{{ pulp_api_host }}:{{ pulp_api_port }}"
+    pulp_url: "{{ pulp_url }}"
     username: "{{ pulp_admin_username }}"
     password: "{{ pulp_default_admin_password }}"
+    validate_certs: "{{ pulp_validate_certs | bool }}"
     name: "{{ item.dist_name }}"
     base_path: "{{ item.base_path }}"
     repository: "{{ item.repo_name }}"


### PR DESCRIPTION
This commit aims to allow one to be more flexible when passing a
`pulp_url`.

Given that this will allow user to specify `https` protocol, we also provide
a way to disable certificate verification.