### PR TITLE
Support RPM installs

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ansible
 name: galaxy_collection
-version: 1.0.5
+version: 1.0.6
 readme: README.md
 
 authors:

--- a/roles/post_install_config/README.md
+++ b/roles/post_install_config/README.md
@@ -4,9 +4,10 @@ Perform post install configuration steps for [GalaxyNG](https://github.com/ansib
 
 Variables
 ---------
-* `pulp_config_dir`: Directory which will contain Pulp configuration files. Defaults to "/etc/pulp". 
-* `pulp_install_dir`: Location of a virtual environment for Pulp and its Python dependencies. Defaults to "/usr/local/lib/pulp". 
-* `pulp_user`: System user that owns and runs Pulp. Defaults to "pulp". 
+* `pulp_install_source`: Set to "packages" for an RPM install, or "pip" for a Python install. Defaults to "pip".
+* `pulp_config_dir`: Directory which will contain Pulp configuration files. Defaults to "/etc/pulp".
+* `pulp_install_dir`: Location of Pulp and dependencies. Defaults to "/usr/local/lib/pulp" for Python installs, or "/usr/bin" for RPM installs.
+* `pulp_user`: System user that owns and runs Pulp. Defaults to "pulp".
 * `pulp_default_admin_password`: Initial password for the Pulp admin. Defaults to "password".
 * `pulp_url`: URL for connecting to the Pulp API server. Defaults to "http://127.0.0.1:24817/".
 * `pulp_settings_file`: Location of the Django setings files. Defaults to "{{ pulp_config_dir }}/settings.py".

--- a/roles/post_install_config/defaults/main.yml
+++ b/roles/post_install_config/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
+pulp_install_source: pip
 pulp_config_dir: '/etc/pulp'
-pulp_install_dir: '/usr/local/lib/pulp'
+pulp_install_dir: '{{ (pulp_install_source == "packages") | ternary("/usr", "/usr/local/lib/pulp") }}' 
 pulp_settings_file: '{{ pulp_config_dir }}/settings.py'
 pulp_user: pulp
 pulp_default_admin_password: password


### PR DESCRIPTION
When installing from RPMs `pulp_intall_dir` should be set to `/usr/bin`.