### PR TITLE
galaxy-importer: Allow greater flexibiliy for configuration

### DIFF
--- a/roles/post_install_config/README.md
+++ b/roles/post_install_config/README.md
@@ -12,3 +12,4 @@ Variables
 * `pulp_url`: URL for connecting to the Pulp API server. Defaults to "http://127.0.0.1:24817/".
 * `pulp_settings_file`: Location of the Django setings files. Defaults to "{{ pulp_config_dir }}/settings.py".
 * `pulp_validate_certs`: Whether or not the TLS certificates should be verified. Defaults to "true".
+* `galaxy_importer_settings`: Key value dictionnary that contains the content of `galaxy-importer.cfg` to be overwritten.

--- a/roles/post_install_config/tasks/main.yml
+++ b/roles/post_install_config/tasks/main.yml
@@ -68,9 +68,13 @@
     state: directory
   become: true
 
-- name: Copy default galaxy-importer config 
-  copy:
-    src: '{{ role_path }}/files/galaxy-importer.cfg'
-    dest: '/etc/galaxy-importer/galaxy-importer.cfg'
+- name: Merging specified galaxy-importer settings with default ones
+  set_fact:
+    _galaxy_importer_settings: '{{ default_galaxy_importer_settings | combine(galaxy_importer_settings | default({})) }}'
+
+- name: Write galaxy-importer config
+  template:
+    src: galaxy-importer.cfg.j2
+    dest: /etc/galaxy-importer/galaxy-importer.cfg
     mode: '0660'
   become: true

--- a/roles/post_install_config/templates/galaxy-importer.cfg.j2
+++ b/roles/post_install_config/templates/galaxy-importer.cfg.j2
@@ -1,0 +1,4 @@
+[galaxy-importer]
+{% for key, value in _galaxy_importer_settings.items() %}
+{{ key | upper }} = {{ value }}
+{% endfor %}

--- a/roles/post_install_config/vars/main.yml
+++ b/roles/post_install_config/vars/main.yml
@@ -33,3 +33,11 @@ pulp_galaxy_permissions:
   - galaxy.change_synclist
   - galaxy.view_synclist
   - galaxy.add_synclist
+default_galaxy_importer_settings:
+  log_level_main: INFO
+  run_flake8: False
+  run_ansible_doc: True
+  run_ansible_lint: True
+  run_ansible_test: False
+  ansible_test_local_image: False
+  infra_osd: False


### PR DESCRIPTION
After giving it a second thought current implementation is a bit strict, and does not allow for flexiblity.

User would have to use the `inline` ansible module to configure it properly. By using this approach user can leverage this role to configure `/etc/galaxy-importer/galaxy-importer.cfg` to their will.