### PR TITLE
Fix remotes url

### DIFF
--- a/roles/post_install_config/tasks/configure_remotes.yml
+++ b/roles/post_install_config/tasks/configure_remotes.yml
@@ -22,7 +22,7 @@
     {{ pulp_install_dir }}/bin/pulpcore-manager
      create-remote
      community
-     https://galaxy.ansible.com/api/v2/collections/
+     https://galaxy.ansible.com/api/
      -r {{ automationhub_tempdir.path }}/requirements.yml
      --distribution community
      --repository community
@@ -36,7 +36,7 @@
     {{ pulp_install_dir }}/bin/pulpcore-manager
      create-remote
      rh-certified
-     https://cloud.redhat.com/api/automation-hub/v3/collections/
+     https://cloud.redhat.com/api/automation-hub/
      --auth_url https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
      --distribution 'red-hat-certified'
      --repository rh-certified


### PR DESCRIPTION
Remote urls should end with `/` but also be the root path for the API