### PR TITLE
Repo/Distro creation conflicts with galaxy_ng migrations

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,10 +1,11 @@
-namespace: ansible
+namespace: ironfroggy
 name: galaxy_collection
-version: 1.0.13
+version: 2.0.0
 readme: README.md
 
 authors:
-  - chouseknecht 
+  - chouseknecht
+  - ironfroggy 
 
 description: Automation for managing a local Galaxy server 
 

--- a/roles/post_install_config/tasks/main.yml
+++ b/roles/post_install_config/tasks/main.yml
@@ -14,29 +14,6 @@
   delay: 2
   retries: 60
 
-- name: Create default repositories
-  pulp.squeezer.ansible_repository:
-    pulp_url: "{{ pulp_url }}"
-    username: "{{ pulp_admin_username }}"
-    password: "{{ pulp_default_admin_password }}"
-    validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.repo_name }}"
-    description: "{{ item.description }}"
-    state: present
-  loop: "{{ pulp_ansible_repositories }}"
-
-- name: Create default distributions
-  pulp.squeezer.ansible_distribution:
-    pulp_url: "{{ pulp_url }}"
-    username: "{{ pulp_admin_username }}"
-    password: "{{ pulp_default_admin_password }}"
-    validate_certs: "{{ pulp_validate_certs | bool }}"
-    name: "{{ item.dist_name }}"
-    base_path: "{{ item.base_path }}"
-    repository: "{{ item.repo_name }}"
-    state: present
-  loop: "{{ pulp_ansible_repositories }}"
-
 - name: Create admins group and assign to the admin user
   command: '{{ pulp_install_dir }}/bin/pulpcore-manager create-group admins --users {{ pulp_admin_username }}'
   no_log: true


### PR DESCRIPTION
Repos/Distros are created by application migrations and don't need created by post_install_config. They actually cause a conflict now, because the tasks here that try to create them fail because they are duplicates.